### PR TITLE
Update README.md to use dendrite master

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ should not be necessary once upstream Dendrite implements threads fully.
 
 To run Hummingbard, you'll need:
 
-- [Dendrite fork](https://github.com/hummingbard/dendrite) configured and running
+- [Dendrite (master branch) ](https://github.com/matrix-org/dendrite) configured and running
 - redis (for session storage)
 - postgres (for various non-Matrix storage)
 - [goose](https://github.com/pressly/goose) for migrations


### PR DESCRIPTION
If I understand correctly, you were using the fork for the AS fixes? We merged those into master so stock Dendrite should be fine now?